### PR TITLE
Add documentation link to help panel

### DIFF
--- a/src/help/input_event_bindings.css
+++ b/src/help/input_event_bindings.css
@@ -55,6 +55,21 @@
   margin-left: 4ex;
 }
 
+.neuroglancer-docs-link-container {
+  padding: 6px 4px;
+}
+
+.neuroglancer-docs-link {
+  color: #4fc3f7;
+  text-decoration: none;
+  font-size: 10pt;
+  font-family: sans-serif;
+}
+
+.neuroglancer-docs-link:hover {
+  text-decoration: underline;
+}
+
 .neuroglancer-build-info {
   font-size: 10pt;
   user-select: text;

--- a/src/help/input_event_bindings.ts
+++ b/src/help/input_event_bindings.ts
@@ -201,6 +201,18 @@ export class InputEventBindingHelpDialog extends SidePanel {
     const { scroll, bindings, toolBinder } = this;
     removeChildren(scroll);
 
+    {
+      const docsLinkContainer = document.createElement("div");
+      docsLinkContainer.classList.add("neuroglancer-docs-link-container");
+      const docsLink = document.createElement("a");
+      docsLink.href = "https://neuroglancer-docs.web.app";
+      docsLink.target = "_blank";
+      docsLink.textContent = "Documentation";
+      docsLink.classList.add("neuroglancer-docs-link");
+      docsLinkContainer.appendChild(docsLink);
+      scroll.appendChild(docsLinkContainer);
+    }
+
     if (typeof NEUROGLANCER_BUILD_INFO !== "undefined") {
       const header = document.createElement("h2");
       header.textContent = "Build info";


### PR DESCRIPTION
Adds a "Documentation" link at the top of the help panel scroll area
pointing to https://neuroglancer-docs.web.app, so users can discover
the documentation site directly from within the app.

https://claude.ai/code/session_01VcLQ824NetFaj6QcLzdXtG